### PR TITLE
Fix gateway request-reply and improve connection handling

### DIFF
--- a/services/gateway/router/topic_router.go
+++ b/services/gateway/router/topic_router.go
@@ -22,7 +22,7 @@ func HandleAllMessage() {
 	}
 }
 
-var PublicChan chan map[net.Conn][]byte
+var PublicChan chan map[net.Conn][]byte = make(chan map[net.Conn][]byte, 100)
 
 func handleChatMessage(msg *nats.Msg) {
 	switch msg.Subject {
@@ -32,6 +32,9 @@ func handleChatMessage(msg *nats.Msg) {
 
 	case natsx.ChatRoomTopic:
 
+	// TODO: The following broadcast logic for ChatPublicTopic is incomplete.
+	// It requires a consumer goroutine for PublicChan to process and send messages to clients.
+	// The message framing (e.g., length-prefixing) also needs to be implemented for these broadcasts.
 	case natsx.ChatPublicTopic:
 		//go func() {
 		//	transport.TcpConnMap.Range(func(key, value any) bool {

--- a/services/gateway/transport/tcp.go
+++ b/services/gateway/transport/tcp.go
@@ -24,6 +24,14 @@ import (
  */
 
 var TcpConnMap = sync.Map{}
+var cmdRouteMap map[int32]string
+
+func init() {
+	cmdRouteMap = map[int32]string{
+		1001: "player.service",
+		2001: natsx.ChatSendTopic,
+	}
+}
 
 func StartTcpServer() {
 	ln, err := net.Listen("tcp", shared.TcpPort)
@@ -43,7 +51,14 @@ func StartTcpServer() {
 }
 
 func handleConnectionTcp(conn net.Conn) {
+	clientAddr := conn.RemoteAddr().String()
+	TcpConnMap.Store(clientAddr, conn)
+	logger.Info("TCP connection established and added to map:", clientAddr)
+
 	defer func() {
+		clientAddr := conn.RemoteAddr().String()
+		TcpConnMap.Delete(clientAddr)
+		logger.Info("TCP connection closed and removed from map:", clientAddr)
 		err := conn.Close()
 		if err != nil {
 			logger.Warn("TCP connection close error:", err)
@@ -74,15 +89,18 @@ func handleConnectionTcp(conn net.Conn) {
 			logger.Warn("TCP server read data error:", err)
 			return
 		}
+		logger.Info("Received message from client", zap.String("clientAddr", clientAddr), zap.Uint32("length", length))
 
 		// 异步处理接收到的消息
 		go func(data []byte) {
 			// 反序列化 GatewayMessage
+			logger.Debug("Attempting to unmarshal GatewayMessage", zap.String("clientAddr", clientAddr), zap.Int("payloadSize", len(data)))
 			var msg protocol.GatewayMessage
 			if err := proto.Unmarshal(data, &msg); err != nil {
 				logger.Warn("TCP server unmarshal error:", err)
 				return
 			}
+			logger.Info("Routing message from client", zap.String("clientAddr", clientAddr), zap.Int32("cmd", msg.Cmd))
 
 			// 根据 cmd 路由到相应的服务
 			serviceSubject := routeByCmd(msg.Cmd)
@@ -106,20 +124,36 @@ func handleConnectionTcp(conn net.Conn) {
 			}
 
 			// 可选：打印或记录已成功发布的消息
-			logger.Info("Published message to NATS. Cmd:", msg.Cmd, "Subject:", serviceSubject)
+			logger.Info("Received NATS response for client", zap.String("clientAddr", clientAddr), zap.Int32("cmd", msg.Cmd), zap.String("subject", serviceSubject), zap.Int("responseSize", len(request.Data)))
+
+			// Send the response back to the TCP client
+			// Create a 4-byte buffer for the length.
+			lenBuf := make([]byte, 4)
+			// Write the length of the response data into this buffer.
+			binary.BigEndian.PutUint32(lenBuf, uint32(len(request.Data)))
+			// Send the length buffer to the client.
+			logger.Debug("Sending response to client", zap.String("clientAddr", clientAddr), zap.Int32("cmd", msg.Cmd), zap.Int("responseSize", len(request.Data)))
+			if _, err := conn.Write(lenBuf); err != nil {
+				logger.Warn("Error sending response length to client:", err)
+				return
+			}
+			// Send the raw response data to the client.
+			if _, err := conn.Write(request.Data); err != nil {
+				logger.Warn("Error sending response data to client:", err)
+				return
+			}
+			logger.Info("Successfully sent response to client", zap.String("clientAddr", clientAddr), zap.Int32("cmd", msg.Cmd), zap.Int("length", len(request.Data)))
 		}(dataBuf)
 	}
 }
 
 func routeByCmd(cmd int32) string {
-	switch cmd {
-	case 1001:
-		return "player.service"
-	case 2001:
-		return natsx.ChatSendTopic
-	default:
-		return "unknown"
+	serviceSubject, ok := cmdRouteMap[cmd]
+	if !ok {
+		logger.Warn("No route found in map for cmd:", zap.Int32("cmd", cmd))
+		return "unknown" // Default value
 	}
+	return serviceSubject
 }
 
 // 发送消息


### PR DESCRIPTION
This commit addresses several issues in the gateway service:

- Modified `handleConnectionTcp` to correctly send NATS responses back to the originating TCP client. This includes length-prefixing the messages.
- Implemented proper management of `TcpConnMap` to add connections on establishment and remove them on closure.
- Refactored `routeByCmd` from a switch statement to a map for better maintainability and added logging for unknown commands.
- Enhanced logging throughout the TCP message handling lifecycle in the gateway, providing better traceability for client address, commands, and message sizes.
- Initialized `PublicChan` in `topic_router.go` to prevent potential panics if the commented-out broadcast code is enabled. Added a TODO comment to clarify the feature's incomplete status.

I could not verify player microservice NATS handling due to missing implementation in the files I examined, but the gateway is now robust in its NATS interactions.